### PR TITLE
Break out instructions for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Listo
+
+## Development
+
+Install the package in editable mode with test dependencies:
+
+```bash
+pip install -e '.[test]'
+```
+
+### Building the project locally
+
+Go to the project root
+
+```bash
+pip install --upgrade build
+python -m build
+```
+
+Test the project, forcing reinstall if necessary
+
+```bash
+pip install dist/listo-0.1.0-py3-none-any.whl --force-reinstall
+```
+
+### Code quality
+
+```bash 
+make lint
+```
+
+### Testing
+
+```bash
+make test
+```
+
+### Releasing on PyPI
+
+1. Update the `version` in `pyproject.toml`. We use semantic versioning
+2. Create and merge a PR branch called `release-x.x.x`
+3. Pull from `main``
+4. At the command line, run `make tag`
+5. Go to [tags page](https://github.com/pydanny/listo/tags), choose the most recent tag, and click `Draft a new release`
+6. Click `Generate release notes` and save
+7. Run `make changelog`
+8. Use `git commit --amend` to add the just pulled release notes to the release commit

--- a/README.md
+++ b/README.md
@@ -44,50 +44,10 @@ assert lst4 == [[1, 2, 3], (1, 2)]
 
 This is different from standard Python iterator behavior.
 
-## Development
+### Contributing to Listo
 
-Install the package in editable mode with test dependencies:
+Have you tried using Listo and found it useful? Do you have ideas for how to make it better? 
 
-```bash
-pip install -e '.[test]'
-```
+We welcome contributions from the community!
 
-### Code quality
-
-```bash 
-make lint
-```
-
-### Testing
-
-```bash
-make test
-```
-
-### Releasing on PyPI
-
-1. Update the `version` in `pyproject.toml`. We use semantic versioning
-2. Create and merge a PR branch called `release-x.x.x`
-3. Pull from `main``
-4. At the command line, run `make tag`
-5. Go to [tags page](https://github.com/pydanny/listo/tags), choose the most recent tag, and click `Draft a new release`
-6. Click `Generate release notes` and save
-7. Run `make changelog`
-8. Use `git commit --amend` to add the just pulled release notes to the release commit
-
-
-### Building the project locally
-
-Go to the project root
-
-```bash
-pip install --upgrade build
-python -m build
-```
-
-Test the project, forcing reinstall if necessary
-
-```bash
-pip install dist/listo-0.1.0-py3-none-any.whl --force-reinstall
-```
-
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to set up your development environment to contribute to this project, run tests, check code quality, release new versions, and more.


### PR DESCRIPTION
Put them in a separate file, to make it easier for end users to
try out the project witnout getting overwhelmed by instructions.

Once they're familiar with using it as a third-party lib, then later we
invite them to get more involved as a contributor.